### PR TITLE
Add null/empty path test

### DIFF
--- a/MegaMekParser.Mtf.Tests/Readers/MtfFileReaderTests.cs
+++ b/MegaMekParser.Mtf.Tests/Readers/MtfFileReaderTests.cs
@@ -44,6 +44,18 @@ public class MtfFileReaderTests
         await action.Should().ThrowAsync<FileNotFoundException>();
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task ReadFileContentAsync_WithNullOrEmptyPath_ShouldThrowArgumentException(string? filePath)
+    {
+        // Act
+        var action = () => _reader.ReadFileContentAsync(filePath!);
+
+        // Assert
+        await action.Should().ThrowAsync<ArgumentException>();
+    }
+
     [Fact]
     public void GetSupportedExtensions_ShouldReturnMtfExtension()
     {


### PR DESCRIPTION
## Summary
- add coverage for `MtfFileReader.ReadFileContentAsync` null and empty paths

## Testing
- `dotnet test MegaMekParser.Mtf.Tests/MegaMekParser.Mtf.Tests.csproj` *(fails: build errors in MegaMekAbstractions project)*

------
https://chatgpt.com/codex/tasks/task_e_6842fcd34e548328af9f2101fdf4bd83