### PR TITLE
Fix NuGet package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more information about MegaMek, visit [the official MegaMek website](https:/
 Install via NuGet:
 
 ```bash
-dotnet add package Mega-Mek-Abstractions
+dotnet add package MegaMekAbstractions
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- correct the NuGet package name in the installation section of the README

Referenced the official MegaMek repository at https://github.com/MegaMek/megamek when confirming the package naming.

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fcd10044832897f360ed2f591f1c