### PR TITLE
Fix damage flags for energy weapons

### DIFF
--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ERPPC.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ERPPC.cs
@@ -8,7 +8,7 @@ public sealed class ERPPC : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="ERPPC"/> class.
     /// </summary>
-    public ERPPC() : base("ER PPC", 2, 6.0m, 15, 0, 7, 14, 23, 15, DamageTypeFlags.DirectFireEnergy Electronics)
+    public ERPPC() : base("ER PPC", 2, 6.0m, 15, 0, 7, 14, 23, 15, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Erlargelaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Erlargelaser.cs
@@ -8,7 +8,7 @@ public sealed class Erlargelaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Erlargelaser"/> class.
     /// </summary>
-    public Erlargelaser() : base("ER Large Laser", 1, 4.0m, 12, 0, 8, 15, 25, 10, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Erlargelaser() : base("ER Large Laser", 1, 4.0m, 12, 0, 8, 15, 25, 10, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ermediumlaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ermediumlaser.cs
@@ -8,7 +8,7 @@ public sealed class Ermediumlaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Ermediumlaser"/> class.
     /// </summary>
-    public Ermediumlaser() : base("ER Medium Laser", 1, 1.0m, 5, 0, 5, 10, 15, 7, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Ermediumlaser() : base("ER Medium Laser", 1, 1.0m, 5, 0, 5, 10, 15, 7, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ermicrolaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ermicrolaser.cs
@@ -8,7 +8,7 @@ public sealed class Ermicrolaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Ermicrolaser"/> class.
     /// </summary>
-    public Ermicrolaser() : base("ER Micro Laser", 1, 0.25.0m, 1, 0, 1, 2, 4, 2, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Ermicrolaser() : base("ER Micro Laser", 1, 0.25.0m, 1, 0, 1, 2, 4, 2, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ersmalllaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Ersmalllaser.cs
@@ -8,7 +8,7 @@ public sealed class Ersmalllaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Ersmalllaser"/> class.
     /// </summary>
-    public Ersmalllaser() : base("ER Small Laser", 1, 0.5.0m, 2, 0, 2, 4, 6, 5, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Ersmalllaser() : base("ER Small Laser", 1, 0.5.0m, 2, 0, 2, 4, 6, 5, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavylargelaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavylargelaser.cs
@@ -8,7 +8,7 @@ public sealed class Heavylargelaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Heavylargelaser"/> class.
     /// </summary>
-    public Heavylargelaser() : base("Heavy Large Laser", 3, 4.0m, 18, 0, 5, 10, 15, 16, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Heavylargelaser() : base("Heavy Large Laser", 3, 4.0m, 18, 0, 5, 10, 15, 16, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavymediumlaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavymediumlaser.cs
@@ -8,7 +8,7 @@ public sealed class Heavymediumlaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Heavymediumlaser"/> class.
     /// </summary>
-    public Heavymediumlaser() : base("Heavy Medium Laser", 2, 1.0m, 7, 0, 3, 6, 9, 10, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Heavymediumlaser() : base("Heavy Medium Laser", 2, 1.0m, 7, 0, 3, 6, 9, 10, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavysmalllaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/Heavysmalllaser.cs
@@ -8,7 +8,7 @@ public sealed class Heavysmalllaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Heavysmalllaser"/> class.
     /// </summary>
-    public Heavysmalllaser() : base("Heavy Small Laser", 1, 0.5.0m, 3, 0, 1, 2, 3, 6, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Heavysmalllaser() : base("Heavy Small Laser", 1, 0.5.0m, 3, 0, 1, 2, 3, 6, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavyLargeLaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavyLargeLaser.cs
@@ -8,7 +8,7 @@ public sealed class ImprovedHeavyLargeLaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="ImprovedHeavyLargeLaser"/> class.
     /// </summary>
-    public ImprovedHeavyLargeLaser() : base("Improved Heavy Large Laser", 4, 1115.0m, 0, 16, 0, 5, 10, 18, DamageTypeFlags.DirectFireEnergy Electronics)
+    public ImprovedHeavyLargeLaser() : base("Improved Heavy Large Laser", 4, 1115.0m, 0, 16, 0, 5, 10, 18, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 3;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavyMediumLaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavyMediumLaser.cs
@@ -8,7 +8,7 @@ public sealed class ImprovedHeavyMediumLaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="ImprovedHeavyMediumLaser"/> class.
     /// </summary>
-    public ImprovedHeavyMediumLaser() : base("Improved Heavy Medium Laser", 1, 79.0m, 0, 10, 0, 3, 6, 7, DamageTypeFlags.DirectFireEnergy Electronics)
+    public ImprovedHeavyMediumLaser() : base("Improved Heavy Medium Laser", 1, 79.0m, 0, 10, 0, 3, 6, 7, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 2;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavySmallLaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/ImprovedHeavySmallLaser.cs
@@ -8,7 +8,7 @@ public sealed class ImprovedHeavySmallLaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="ImprovedHeavySmallLaser"/> class.
     /// </summary>
-    public ImprovedHeavySmallLaser() : base("Improved Heavy Small Laser", 05, 3.0m, 0, 6, 0, 1, 2, 3, DamageTypeFlags.DirectFireEnergy Electronics)
+    public ImprovedHeavySmallLaser() : base("Improved Heavy Small Laser", 05, 3.0m, 0, 6, 0, 1, 2, 3, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 1;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/PlasmaCannon.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/Clan/PlasmaCannon.cs
@@ -8,7 +8,7 @@ public sealed class PlasmaCannon : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="PlasmaCannon"/> class.
     /// </summary>
-    public PlasmaCannon() : base("Plasma Cannon", 3, 1318.0m, 0, 0, 0, 6, 12, 7, DamageTypeFlags.DirectFireEnergy Electronics)
+    public PlasmaCannon() : base("Plasma Cannon", 3, 1318.0m, 0, 0, 0, 6, 12, 7, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 1;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/BinaryBlazerCannon.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/BinaryBlazerCannon.cs
@@ -8,7 +8,7 @@ public sealed class BinaryBlazerCannon : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="BinaryBlazerCannon"/> class.
     /// </summary>
-    public BinaryBlazerCannon() : base("Binary (Blazer) Cannon", 4, 9.0m, 16, 0, 5, 10, 15, 12, DamageTypeFlags.DirectFireEnergy Electronics)
+    public BinaryBlazerCannon() : base("Binary (Blazer) Cannon", 4, 9.0m, 16, 0, 5, 10, 15, 12, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/ERPPC.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/ERPPC.cs
@@ -8,7 +8,7 @@ public sealed class ERPPC : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="ERPPC"/> class.
     /// </summary>
-    public ERPPC() : base("ER PPC", 3, 7.0m, 15, 0, 7, 14, 23, 10, DamageTypeFlags.DirectFireEnergy Electronics)
+    public ERPPC() : base("ER PPC", 3, 7.0m, 15, 0, 7, 14, 23, 10, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Erlargelaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Erlargelaser.cs
@@ -8,7 +8,7 @@ public sealed class Erlargelaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Erlargelaser"/> class.
     /// </summary>
-    public Erlargelaser() : base("ER Large Laser", 2, 5.0m, 12, 0, 7, 14, 19, 8, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Erlargelaser() : base("ER Large Laser", 2, 5.0m, 12, 0, 7, 14, 19, 8, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Ermediumlaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Ermediumlaser.cs
@@ -8,7 +8,7 @@ public sealed class Ermediumlaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Ermediumlaser"/> class.
     /// </summary>
-    public Ermediumlaser() : base("ER Medium Laser", 1, 1.0m, 5, 0, 4, 8, 12, 5, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Ermediumlaser() : base("ER Medium Laser", 1, 1.0m, 5, 0, 4, 8, 12, 5, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Ersmalllaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Ersmalllaser.cs
@@ -8,7 +8,7 @@ public sealed class Ersmalllaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Ersmalllaser"/> class.
     /// </summary>
-    public Ersmalllaser() : base("ER Small Laser", 1, 0.5.0m, 2, 0, 2, 4, 5, 3, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Ersmalllaser() : base("ER Small Laser", 1, 0.5.0m, 2, 0, 2, 4, 5, 3, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Heavyppc.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Heavyppc.cs
@@ -8,7 +8,7 @@ public sealed class Heavyppc : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Heavyppc"/> class.
     /// </summary>
-    public Heavyppc() : base("Heavy PPC", 4, 10.0m, 15, 3, 6, 12, 18, 15, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Heavyppc() : base("Heavy PPC", 4, 10.0m, 15, 3, 6, 12, 18, 15, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Largelaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Largelaser.cs
@@ -8,7 +8,7 @@ public sealed class Largelaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Largelaser"/> class.
     /// </summary>
-    public Largelaser() : base("Large Laser", 2, 5.0m, 8, 0, 5, 10, 15, 8, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Largelaser() : base("Large Laser", 2, 5.0m, 8, 0, 5, 10, 15, 8, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Lightppc.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Lightppc.cs
@@ -8,7 +8,7 @@ public sealed class Lightppc : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Lightppc"/> class.
     /// </summary>
-    public Lightppc() : base("Light PPC", 2, 3.0m, 5, 3, 6, 12, 18, 5, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Lightppc() : base("Light PPC", 2, 3.0m, 5, 3, 6, 12, 18, 5, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Mediumlaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Mediumlaser.cs
@@ -8,7 +8,7 @@ public sealed class Mediumlaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Mediumlaser"/> class.
     /// </summary>
-    public Mediumlaser() : base("Medium Laser", 1, 1.0m, 3, 0, 3, 6, 9, 5, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Mediumlaser() : base("Medium Laser", 1, 1.0m, 3, 0, 3, 6, 9, 5, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/PlasmaRifle.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/PlasmaRifle.cs
@@ -8,7 +8,7 @@ public sealed class PlasmaRifle : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="PlasmaRifle"/> class.
     /// </summary>
-    public PlasmaRifle() : base("Plasma Rifle", 6, 1115.0m, 0, 10, 0, 5, 10, 10, DamageTypeFlags.DirectFireEnergy Electronics)
+    public PlasmaRifle() : base("Plasma Rifle", 6, 1115.0m, 0, 10, 0, 5, 10, 10, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 2;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Smalllaser.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Smalllaser.cs
@@ -8,7 +8,7 @@ public sealed class Smalllaser : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Smalllaser"/> class.
     /// </summary>
-    public Smalllaser() : base("Small Laser", 1, 0.5.0m, 1, 0, 1, 2, 3, 3, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Smalllaser() : base("Small Laser", 1, 0.5.0m, 1, 0, 1, 2, 3, 3, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 0;
     }

--- a/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Snubnoseppc.cs
+++ b/MegaMekAbstractions/Mechs/Equipment/Weapons/InnerSphere/Snubnoseppc.cs
@@ -8,7 +8,7 @@ public sealed class Snubnoseppc : Weapon
     /// <summary>
     /// Initializes a new instance of the <see cref="Snubnoseppc"/> class.
     /// </summary>
-    public Snubnoseppc() : base("Snub-Nose PPC", 6, 1415.0m, 0, 1085, 0, 9, 13, 10, DamageTypeFlags.DirectFireEnergy Electronics)
+    public Snubnoseppc() : base("Snub-Nose PPC", 6, 1415.0m, 0, 1085, 0, 9, 13, 10, DamageTypeFlags.DirectFireEnergy | DamageTypeFlags.Electronics)
     {
         ShotsPerTon = 2;
     }


### PR DESCRIPTION
## Summary
- fix `DamageTypeFlags` for many energy weapons so electronics flag is included

## Testing
- `dotnet build MegaMekAbstractions.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fcce21d0832886d5e8c6846329b3