### PR TITLE
Fix typo in Quirk enum name

### DIFF
--- a/MegaMekAbstractions/Common/Quirk.cs
+++ b/MegaMekAbstractions/Common/Quirk.cs
@@ -52,7 +52,7 @@ public enum Quirk
     InnerSphereUbiquitous,
     ClanUbiquitous,
     VariableRangeLong,
-    VariableRangShort,
+    VariableRangeShort,
     VestigialHandsLeftArm,
     VestigialHandsRightArm,
     VtolRotorCoaxial,


### PR DESCRIPTION
## Summary
- fix spelling mistake in `Quirk` enum

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fcc9feac8328b6493d9541caa4e9