### PR TITLE
Add support for newer MTF format

### DIFF
--- a/MegaMekAbstractions/Mechs/Mech.cs
+++ b/MegaMekAbstractions/Mechs/Mech.cs
@@ -22,6 +22,16 @@ public class Mech
     public required IList<Quirk> Quirks { get; set; }
     public int Mass { get; set; }
 
+    // Extended metadata from newer MTF files
+    public string Myomer { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string PrimaryFactory { get; set; } = string.Empty;
+    public Dictionary<string, string> SystemManufacturers { get; set; } = new();
+    public string Overview { get; set; } = string.Empty;
+    public string Capabilities { get; set; } = string.Empty;
+    public string Deployment { get; set; } = string.Empty;
+    public string History { get; set; } = string.Empty;
+
     // Core Systems
     public required Engine Engine { get; set; }
     public required Gyro Gyro { get; set; }

--- a/MegaMekAbstractions/Parsers/Constants/MtfConstants.cs
+++ b/MegaMekAbstractions/Parsers/Constants/MtfConstants.cs
@@ -119,6 +119,46 @@ public static class MtfConstants
         /// Cockpit section identifier
         /// </summary>
         public const string Cockpit = "Cockpit:";
+
+        /// <summary>
+        /// Myomer type section identifier
+        /// </summary>
+        public const string Myomer = "myomer:";
+
+        /// <summary>
+        /// Manufacturer section identifier
+        /// </summary>
+        public const string Manufacturer = "manufacturer:";
+
+        /// <summary>
+        /// Primary factory section identifier
+        /// </summary>
+        public const string PrimaryFactory = "primaryfactory:";
+
+        /// <summary>
+        /// System manufacturer section identifier
+        /// </summary>
+        public const string SystemManufacturer = "systemmanufacturer:";
+
+        /// <summary>
+        /// Overview text section identifier
+        /// </summary>
+        public const string Overview = "overview:";
+
+        /// <summary>
+        /// Capabilities text section identifier
+        /// </summary>
+        public const string Capabilities = "capabilities:";
+
+        /// <summary>
+        /// Deployment text section identifier
+        /// </summary>
+        public const string Deployment = "deployment:";
+
+        /// <summary>
+        /// History text section identifier
+        /// </summary>
+        public const string History = "history:";
     }
 
     /// <summary>

--- a/MegaMekDb/Entities/MechEntity.cs
+++ b/MegaMekDb/Entities/MechEntity.cs
@@ -28,6 +28,16 @@ public class MechEntity
     public GroundRole GroundRole { get; set; }
     public int Mass { get; set; }
 
+    // Extended metadata
+    public string Myomer { get; set; } = string.Empty;
+    public string Manufacturer { get; set; } = string.Empty;
+    public string PrimaryFactory { get; set; } = string.Empty;
+    public string SystemManufacturersJson { get; set; } = string.Empty;
+    public string Overview { get; set; } = string.Empty;
+    public string Capabilities { get; set; } = string.Empty;
+    public string Deployment { get; set; } = string.Empty;
+    public string History { get; set; } = string.Empty;
+
     // Core Systems
     public int EngineRating { get; set; }
     public EngineType EngineType { get; set; }

--- a/MegaMekDb/Services/MtfImportService.cs
+++ b/MegaMekDb/Services/MtfImportService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using MegaMekAbstractions.Mechs;
 using MegaMekAbstractions.Mechs.Equipment;
 using MegaMekAbstractions.Parsers.Interfaces;
@@ -153,6 +154,15 @@ public class MtfImportService
         mechEntity.RulesLevel = mech.RulesLevel;
         mechEntity.GroundRole = mech.GroundRole;
         mechEntity.Mass = mech.Mass;
+
+        mechEntity.Myomer = mech.Myomer;
+        mechEntity.Manufacturer = mech.Manufacturer;
+        mechEntity.PrimaryFactory = mech.PrimaryFactory;
+        mechEntity.Overview = mech.Overview;
+        mechEntity.Capabilities = mech.Capabilities;
+        mechEntity.Deployment = mech.Deployment;
+        mechEntity.History = mech.History;
+        mechEntity.SystemManufacturersJson = JsonSerializer.Serialize(mech.SystemManufacturers);
         
         // Core systems
         mechEntity.EngineRating = mech.Engine.Rating;

--- a/MegaMekParser.Mtf.Tests/Parsers/MtfParserTests.cs
+++ b/MegaMekParser.Mtf.Tests/Parsers/MtfParserTests.cs
@@ -11,12 +11,16 @@ public class MtfParserTests
     private readonly MtfParser _parser;
     private readonly string _sampleMtfPath;
     private readonly string _sampleMtfContent;
+    private readonly string _modernMtfPath;
+    private readonly string _modernMtfContent;
 
     public MtfParserTests()
     {
         _parser = new MtfParser();
         _sampleMtfPath = Path.Combine("TestData", "Mechs", "MAD-3R.mtf");
         _sampleMtfContent = File.ReadAllText(_sampleMtfPath);
+        _modernMtfPath = Path.Combine("TestData", "Mechs", "Archer C 2.mtf");
+        _modernMtfContent = File.ReadAllText(_modernMtfPath);
     }
 
     [Fact]
@@ -72,6 +76,20 @@ public class MtfParserTests
         mech.Quirks.Should().Contain(Quirk.LowProfile);
         mech.Quirks.Should().Contain(Quirk.DirectTorsoMount);
         mech.Quirks.Should().Contain(Quirk.ExposedLinkage);
+    }
+
+    [Fact]
+    public async Task ParseMechDataAsync_WithModernFile_ShouldParseAdditionalFields()
+    {
+        var mech = await _parser.ParseMechDataAsync(_modernMtfContent);
+
+        mech.Myomer.Should().Be("Standard");
+        mech.Manufacturer.Should().Be("Refit");
+        mech.PrimaryFactory.Should().Be("Various");
+        mech.SystemManufacturers.Should().ContainKey("ENGINE");
+        mech.Overview.Should().StartWith("One of the most iconic");
+        mech.Quirks.Should().Contain(Quirk.BattleFistsLeftArm);
+        mech.Quirks.Should().Contain(Quirk.InnerSphereUbiquitous);
     }
 
     [Fact]

--- a/MegaMekParser.Mtf/Parsers/MtfParser.cs
+++ b/MegaMekParser.Mtf/Parsers/MtfParser.cs
@@ -39,7 +39,15 @@ public class MtfParser : IMtfParser
         "Cockpit",
         "Heat Sinks",
         "Armor",
-        "Weapons"
+        "Weapons",
+        "myomer",
+        "manufacturer",
+        "primaryfactory",
+        "systemmanufacturer",
+        "overview",
+        "capabilities",
+        "deployment",
+        "history"
     };
 
     private static readonly Regex SectionHeaderRegex = new(@"^(" + string.Join("|", MainSections.Select(Regex.Escape)) + @"):.*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/MegaMekParser.Mtf/Parsers/MtfSectionParsers.cs
+++ b/MegaMekParser.Mtf/Parsers/MtfSectionParsers.cs
@@ -27,7 +27,15 @@ internal static class MtfSectionParsers
         { MtfConstants.Sections.WalkMP, ParseWalkMP },
         { MtfConstants.Sections.JumpMP, ParseJumpMP },
         { MtfConstants.Sections.Quirk, ParseQuirk },
-        { MtfConstants.Sections.WeaponQuirk, ParseWeaponQuirk }
+        { MtfConstants.Sections.WeaponQuirk, ParseWeaponQuirk },
+        { MtfConstants.Sections.Myomer, ParseMyomer },
+        { MtfConstants.Sections.Manufacturer, ParseManufacturer },
+        { MtfConstants.Sections.PrimaryFactory, ParsePrimaryFactory },
+        { MtfConstants.Sections.SystemManufacturer, ParseSystemManufacturer },
+        { MtfConstants.Sections.Overview, ParseOverview },
+        { MtfConstants.Sections.Capabilities, ParseCapabilities },
+        { MtfConstants.Sections.Deployment, ParseDeployment },
+        { MtfConstants.Sections.History, ParseHistory }
     };
 
     public static void ParseSection(string sectionName, string[] lines, Mech mech)
@@ -415,21 +423,21 @@ internal static class MtfSectionParsers
                 {
                     "command_mech" => (Quirk?)Quirk.CommandMech,
                     "imp_life_support" => (Quirk?)Quirk.ImprovedLifeSupport,
-                    "battle_fists_la" => (Quirk?)Quirk.LowArms,
-                    "battle_fists_ra" => (Quirk?)Quirk.NoEject,
-                    "imp_target_short" => (Quirk?)Quirk.FlawedCooling,
-                    "imp_target_med" => (Quirk?)Quirk.AntiAir,
-                    "imp_target_long" => (Quirk?)Quirk.NonStandard,
-                    "easy_maintain" => (Quirk?)Quirk.EasyPilot,
-                    "ext_twist" => (Quirk?)Quirk.Unbalanced,
-                    "pro_actuator" => (Quirk?)Quirk.OverheadArms,
-                    "imp_com" => (Quirk?)Quirk.ReinforcedLegs,
-                    "imp_sensors" => (Quirk?)Quirk.SensorGhosts,
-                    "bad_rep_is" => (Quirk?)Quirk.FlawedCooling,
-                    "bad_rep_clan" => (Quirk?)Quirk.FineManipulators,
-                    "difficult_maintain" => (Quirk?)Quirk.PoorPerformance,
-                    "ubiquitous_is" => (Quirk?)Quirk.DifficultMaintain,
-                    "ubiquitous_clan" => (Quirk?)Quirk.Obsolete,
+                    "battle_fists_la" => (Quirk?)Quirk.BattleFistsLeftArm,
+                    "battle_fists_ra" => (Quirk?)Quirk.BattleFistsRightArm,
+                    "imp_target_short" => (Quirk?)Quirk.ImprovedTargetingShort,
+                    "imp_target_med" => (Quirk?)Quirk.ImprovedTargetingMedium,
+                    "imp_target_long" => (Quirk?)Quirk.ImprovedTargetingLong,
+                    "easy_maintain" => (Quirk?)Quirk.EasyToMaintain,
+                    "ext_twist" => (Quirk?)Quirk.ExtendedTorsoTwist,
+                    "pro_actuator" => (Quirk?)Quirk.ProtectedActuators,
+                    "imp_com" => (Quirk?)Quirk.ImprovedCommunications,
+                    "imp_sensors" => (Quirk?)Quirk.ImprovedSensors,
+                    "bad_rep_is" => (Quirk?)Quirk.InnerSphereBadReputation,
+                    "bad_rep_clan" => (Quirk?)Quirk.ClanBadReputation,
+                    "difficult_maintain" => (Quirk?)Quirk.DifficultMaintain,
+                    "ubiquitous_is" => (Quirk?)Quirk.InnerSphereUbiquitous,
+                    "ubiquitous_clan" => (Quirk?)Quirk.ClanUbiquitous,
                     _ => null
                 };
 
@@ -465,6 +473,102 @@ internal static class MtfSectionParsers
                 {
                     mech.Quirks.Add(quirk);
                 }
+            }
+        }
+    }
+
+    private static void ParseMyomer(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.Myomer))
+            {
+                mech.Myomer = GetValue(line, MtfConstants.Sections.Myomer) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParseManufacturer(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.Manufacturer))
+            {
+                mech.Manufacturer = GetValue(line, MtfConstants.Sections.Manufacturer) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParsePrimaryFactory(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.PrimaryFactory))
+            {
+                mech.PrimaryFactory = GetValue(line, MtfConstants.Sections.PrimaryFactory) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParseSystemManufacturer(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.SystemManufacturer))
+            {
+                var value = GetValue(line, MtfConstants.Sections.SystemManufacturer);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    var parts = value.Split(':', 2);
+                    if (parts.Length == 2)
+                    {
+                        mech.SystemManufacturers[parts[0]] = parts[1];
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ParseOverview(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.Overview))
+            {
+                mech.Overview = GetValue(line, MtfConstants.Sections.Overview) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParseCapabilities(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.Capabilities))
+            {
+                mech.Capabilities = GetValue(line, MtfConstants.Sections.Capabilities) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParseDeployment(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.Deployment))
+            {
+                mech.Deployment = GetValue(line, MtfConstants.Sections.Deployment) ?? string.Empty;
+            }
+        }
+    }
+
+    private static void ParseHistory(string[] lines, Mech mech)
+    {
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(MtfConstants.Sections.History))
+            {
+                mech.History = GetValue(line, MtfConstants.Sections.History) ?? string.Empty;
             }
         }
     }


### PR DESCRIPTION
## Summary
- parse new MTF sections like myomer, manufacturer, factory details and lore text
- map newer quirk keys to proper enum values
- store new fields in Mech, database entity and import service
- expand parser tests for modern MTF files

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb37f6c88328be46ca15af14ffca