### PR TITLE
Add clan omni mechs for parser tests

### DIFF
--- a/MegaMekParser.Mtf.Tests/Parsers/MtfParserSampleFilesTests.cs
+++ b/MegaMekParser.Mtf.Tests/Parsers/MtfParserSampleFilesTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using MegaMekAbstractions.Mechs;
+using MegaMekParser.Mtf.Parsers;
+
+namespace MegaMekParser.Mtf.Tests.Parsers;
+
+public class MtfParserSampleFilesTests
+{
+    private readonly MtfParser _parser = new();
+
+    [Theory]
+    [InlineData("Locust LCT-1V.mtf", 20, "Locust", "LCT-1V", 160, EngineType.Standard, 8)]
+    [InlineData("Shadow Hawk SHD-2H.mtf", 55, "Shadow Hawk", "SHD-2H", 275, EngineType.Standard, 5)]
+    [InlineData("Catapult CPLT-C1.mtf", 65, "Catapult", "CPLT-C1", 260, EngineType.Standard, 4)]
+    [InlineData("Warhammer WHM-6R.mtf", 70, "Warhammer", "WHM-6R", 280, EngineType.Standard, 4)]
+    [InlineData("Atlas AS7-D.mtf", 100, "Atlas", "AS7-D", 300, EngineType.Standard, 3)]
+    [InlineData("Mad Cat (Timber Wolf) Prime.mtf", 75, "Mad Cat", "Prime", 375, EngineType.Standard, 5)]
+    [InlineData("Archer C 2.mtf", 70, "Archer", "C 2", 280, EngineType.Standard, 4)]
+    [InlineData("Rifleman C 3.mtf", 60, "Rifleman", "C 3", 240, EngineType.Standard, 4)]
+    [InlineData("Phoenix Hawk C.mtf", 45, "Phoenix Hawk", "C", 270, EngineType.XL, 6)]
+    [InlineData("Thor (Summoner) Prime.mtf", 70, "Thor", "Prime", 350, EngineType.XL, 5)]
+    [InlineData("Black Hawk (Nova) Prime.mtf", 50, "Black Hawk", "Prime", 250, EngineType.XL, 5)]
+    [InlineData("Ryoken (Stormcrow) Prime.mtf", 55, "Ryoken", "Prime", 330, EngineType.XL, 6)]
+    [InlineData("Daishi (Dire Wolf) Prime.mtf", 100, "Daishi", "Prime", 300, EngineType.XL, 3)]
+    public async Task ParseMechDataAsync_ShouldParseBasicFields(string fileName, int mass, string chassis, string model, int engineRating, EngineType engineType, int walkMp)
+    {
+        var path = Path.Combine("TestData", "Mechs", fileName);
+        var content = await File.ReadAllTextAsync(path);
+
+        var mech = await _parser.ParseMechDataAsync(content);
+
+        mech.Mass.Should().Be(mass);
+        mech.Chassis.Should().Be(chassis);
+        mech.Model.Should().Be(model);
+        mech.Engine.Rating.Should().Be(engineRating);
+        mech.Engine.Type.Should().Be(engineType);
+        mech.Engine.WalkingMP.Should().Be(walkMp);
+    }
+}

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Atlas AS7-D.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Atlas AS7-D.mtf
@@ -1,0 +1,175 @@
+chassis:Atlas
+model:AS7-D
+mul id:140
+
+Config:Biped
+techbase:Inner Sphere
+era:2755
+source:TRO: 3039
+rules level:1
+role:Juggernaut
+
+quirk:battle_fists_la
+quirk:battle_fists_ra
+quirk:command_mech
+quirk:distracting
+quirk:imp_com
+
+mass:100
+engine:300 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:20 Single
+walk mp:3
+jump mp:0
+
+armor:Standard(Inner Sphere)
+LA armor:34
+RA armor:34
+LT armor:32
+RT armor:32
+CT armor:47
+HD armor:9
+LL armor:41
+RL armor:41
+RTL armor:10
+RTR armor:10
+RTC armor:14
+
+Weapons:7
+Medium Laser, Left Arm
+Medium Laser, Right Arm
+LRM 20, Left Torso
+SRM 6, Left Torso
+AC/20, Right Torso
+Medium Laser, Center Torso
+Medium Laser, Center Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+Heat Sink
+Medium Laser
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+Heat Sink
+Medium Laser
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Heat Sink
+LRM 20
+LRM 20
+LRM 20
+LRM 20
+LRM 20
+SRM 6
+SRM 6
+IS Ammo LRM-20
+IS Ammo LRM-20
+IS Ammo SRM-6
+-Empty-
+
+Right Torso:
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+Autocannon/20
+IS Ammo AC/20
+IS Ammo AC/20
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Medium Laser (R)
+Medium Laser (R)
+
+Head:
+Life Support
+Sensors
+Cockpit
+Heat Sink
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:"A 'Mech as powerful as possible, as impenetrable as possible, and as ugly and foreboding as conceivable, so that fear itself will be our ally.”-Aleksandr Kerensky
+
+capabilities:The Atlas is probably the best-known BattleMech to ever set foot on the modern battlefield. Designed with specifications from Aleksandr Kerensky himself in 2755 in the midst of the Cameron Edicts, the Atlas was originally intended to ensure SLDF superiority over the Star League member states. Carrying the largest LRM launcher, the largest autocannon, and the largest SRM launcher possible, the Atlas can deal frightening amounts of damage in short amounts of time. Often used as a command vehicle, the Atlas mounts an advanced antenna and communications array, allowing it to engage in surface-to-space communications in real time. The massive 19-ton hide of armor that protects the Atlas makes it a difficult foe to take down. Indeed, most MechWarriors choose to fall back rather than face one head-on, as its lumbering gait means it can rarely catch up to other 'Mechs that choose to flee it. A full year of development went into crafting the famous "Death's Head" of the 'Mech to achieve the perfect ratio of functionality and fear. The head is also quite roomy and allows a small satellite dish to be mounted for surface-to-space communications. During combat the pilot can easily fold up the dish and store it within a protective portion of the head.
+
+deployment:The Atlas is armed with a multitude of weapons for both long and short range combat, all designed specifically to be as visible as possible so as to strike fear in the hearts of its enemies. For long ranges, the 'Mech carries a FarFire Maxi-Rack LRM-20 in the left torso that allows it to both fire directly at an enemy target at long range, and to give indirect fire support when needed. Unable to fit a full twenty-tube system on the 'Mech, the FarFire instead launches the missiles in waves of five over the course of ten seconds and carries two tons of reloads for twelve such salvos. For close range combat the 'Mech is armed with a Defiance 'Mech Hunter Autocannon/20 in the right torso with two tons of ammo. Although lacking a cooling jacket and liable to overheat, the massive autocannon gives the Atlas the firepower to take on an entire 'Mech company. To back up the AC/20 the Atlas carries four Defiance B3M Medium Lasers, one in each arm and two mounted in the rear center torso, and a TharHes Maxi SRM-6 launcher with one ton of missiles in the right torso (the aperture between the SRM and LRM launchers is not another weapon but an omnicoupling for power and coolant cable connection). Furthermore the Atlas is equipped with hand actuators which, combined with its sheer weight and power, makes it a potent hand-to-hand fighter. Accounts of Atlases actually picking up medium-weight 'Mechs and throwing them around like toys makes for suitable horror stories and further enhances the aura of the 'Mech.
+
+history:Though the inexorable arming of the Great Houses continued, the Atlas proved itself to be everything General Kerensky requested. With the largest amount of armor of nearly any 'Mech, crippling firepower, and the foreboding skull-shaped "Death's Head" cockpit/head assembly, the Atlas lived up to its reputation. The mere sight of an Atlas had been known to make even a veteran MechWarrior break out in a cold sweat, and theoretically a single Atlas can take on and wipe out an entire battalion of Stingers in exchange for minor armor loss. The Atlas' first combat trials came during the Amaris Civil War, where it served an instrumental role as a powerful command vehicle. Though General Kerensky is well-known for being the one who kicked down the palace doors of the Usurper in his Orion, it was his close friend Aaron DeChavilier who, in his Atlas, weathered the storm of enemy fire and breached the protective wall surrounding the complex. After this conflict it was therefore with little surprise that the General wished for all of these 'Mechs to accompany him on Operation Exodus, but ironically of those MechWarriors who refused his summons fully two-thirds were Atlas pilots. These units were spread among the Successor States and Atlas factories on Al Na'ir, Hesperus II and Quentin would continue production of the 'Mech through the Succession Wars. Most commanders were loath to tamper too much with such a successful 'Mech, but the recovery of the Helm Memory Core resulted in a number of ancient designs being updated with lostech, and the Atlas was no exception. The new AS7-K model was released in 3049, just in time to fight off the Clan Invasion. The Federated Commonwealth also briefly began production of their own model, the AS7-S, although following the civil war that line was discontinued and further variants have been introduced by the Lyran Alliance and Draconis Combine. Despite its age, well into the end of the thirty-first century there were no plans to replace the Atlas, and even the most cutting-edge designs will stop and pause when faced with the prospect of an Atlas bearing down on them.
+
+manufacturer:Yori 'Mech Works,HildCo Interplanetary,Witten Industries,Defiance Industries,Independence Weaponry
+primaryfactory:Al Na'ir,Carver V/Liberty,Hesperus II,Hesperus II,Quentin
+systemmanufacturer:CHASSIS:Foundation Type 10X
+systemmanufacturer:ENGINE:Vlar 300
+systemmanufacturer:ARMOR:Durallex Special Heavy
+systemmanufacturer:COMMUNICATIONS:Angst Discom
+systemmanufacturer:TARGETING:Angst Accuracy

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Black Hawk (Nova) Prime.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Black Hawk (Nova) Prime.mtf
@@ -1,0 +1,183 @@
+chassis:Black Hawk
+clanname:Nova
+model:Prime
+mul id:342
+
+Config:Biped Omnimech
+techbase:Clan
+era:2870
+source:TRO: 3050
+rules level:2
+role:Skirmisher
+
+
+quirk:combat_computer
+quirk:low_profile
+
+
+mass:50
+engine:250 XL (Clan) Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:18 Clan Double
+base chassis heat sinks:10
+walk mp:5
+jump mp:5
+
+armor:Standard(Clan)
+LA armor:16
+RA armor:16
+LT armor:16
+RT armor:16
+CT armor:23
+HD armor:9
+LL armor:20
+RL armor:20
+RTL armor:8
+RTR armor:8
+RTC armor:8
+
+Weapons:12
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Right Arm
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Jump Jet
+-Empty-
+
+Head:
+Life Support
+Sensors
+Cockpit
+-Empty-
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Nova is a versatile medium OmniMech that is capable of acting as a workhorse design in most forces. In fact, the design is so well balanced that it inspired the creation of the Black Hawk-KU, an Inner Sphere design based on the Nova and named using the Inner Sphere code name for this 'Mech: Black Hawk.
+
+capabilities:Equipped with a 250 XL Model SF-2 Fusion Engine, the Nova has a ground speed of 86.4 km/h that allows it to keep up with most heavy and assault 'Mechs while being outpaced by most lighter 'Mechs. However, the Nova remains very maneuverable through the use of five jump jets, allowing the Nova to jump up to 150 meters. The fourteen double heat sinks that the Nova mounts are barely sufficient to handle its heavy heat load of its variants. The Nova is also protected by ten tons of armor, providing the 'Mech with ninety-six percent of its maximum armor protection.
+
+deployment:In its primary configuration the Nova is a devastating close combat 'Mech and battle armor killer that is capable of delivering a powerful barrage with its twelve ER Medium Lasers. To help it use these as effectively as possible, the Nova has added four more double heat sinks bringing the total up to eighteen. Even with the added double heat sinks, the Nova prime is capable of producing almost twice as much heat as it can dissipate.
+
+history:The Black Hawk's debut battle was the combined assault on Kindraa Smythe-Jewel on Foster in 2872 launched by the Hell's Horses, Clan Coyote and Kindraa Payne that saw the Smythe-Jewels wiped out as a faction. However, the number of Novas has been diminishing. Only spare parts have been in production since 2921. Designed as an early OmniMech by Clan Hell's Horses, the Nova was produced at the famous Tokasha Mechworks beginning in 2870. At the time of its introduction, the Nova was designed for infantry support, and was the first OmniMech designed with hardpoints allowing Elementals to easily mount and dismount the chassis. However, after Tokasha was taken by Clan Ghost Bear during the Battle of Tokasha, production of the Nova ceased. Since 2921, every Clan has acquired Nova OmniMechs as isorla. Although the last Nova factory was replaced to create Pouncers, the very few remaining in Clan Space have gotten into the hands of Aggressor Mechwarriors.
+
+manufacturer:Tokasha MechWorks, Olivetti Weaponry
+primaryfactory:Tokasha, Sudeten
+systemmanufacturer:CHASSIS:Star League XTA
+systemmanufacturer:ENGINE:250 XL Model SF-2
+systemmanufacturer:ARMOR:Forge Type HH30
+systemmanufacturer:JUMPJET:Clan Standard Type A2
+systemmanufacturer:COMMUNICATIONS:CH3B
+systemmanufacturer:TARGETING:Version Omega-V TTS
+

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Catapult CPLT-C1.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Catapult CPLT-C1.mtf
@@ -1,0 +1,177 @@
+chassis:Catapult
+model:CPLT-C1
+mul id:478
+
+Config:Biped
+TechBase:Inner Sphere
+Era:2561
+Source:TRO: 3039
+Rules Level:1
+role:Missile Boat
+
+
+
+
+quirk:no_arms
+quirk:weak_head_1
+
+
+Mass:65
+Engine:260 Fusion Engine
+Structure:Standard
+Myomer:Standard
+
+Heat Sinks:15 Single
+Walk MP:4
+Jump MP:4
+
+Armor:Standard(Inner Sphere)
+LA Armor:13
+RA Armor:13
+LT Armor:19
+RT Armor:19
+CT Armor:24
+HD Armor:9
+LL Armor:18
+RL Armor:18
+RTL Armor:8
+RTR Armor:8
+RTC Armor:11
+
+Weapons:6
+Medium Laser, Left Torso
+Medium Laser, Right Torso
+Medium Laser, Center Torso
+Medium Laser, Center Torso
+LRM 15, Right Arm
+LRM 15, Left Arm
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+LRM 15
+LRM 15
+LRM 15
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+LRM 15
+LRM 15
+LRM 15
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Jump Jet
+Jump Jet
+Medium Laser
+IS Ammo LRM-15
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Jump Jet
+Jump Jet
+Medium Laser
+IS Ammo LRM-15
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Medium Laser
+Medium Laser
+
+Head:
+Life Support
+Sensors
+Cockpit
+Heat Sink
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+
+Overview: The Catapult, though a well-designed BattleMech, has had a tumultuous existence. Produced by Hollis Incorporated in record numbers for the SLDF, the Terran Hegemony ultimately decided to forgo contract renewal, leaving Hollis with a BattleMech line but no customer. When the facility was eventually retooled to produce the BattleMaster, they chose to completely abandon their Catapult chassis, and its numbers began to decline. The attrition of the Succession Wars left the Draconis Combine with many Catapults but no parts for them. Contracting Yori Mech Works, a production line was eventually built and new Catapults began entering the DCMS by 3033. The Capellan Confederation would follow suit and the Catapult would finally claim the popularity that it deserved.
+
+Capabilities: Carrying two LRM launchers in its "ears" and four medium lasers in its body, the Catapult was a fire support 'Mech akin to the slightly larger Archer. The inclusion of jump jets, though, and the placement of the lasers allowed many Catapults to be their own bodyguards. Many Catapult MechWarriors choose to fire all of their LRM missiles at their chosen targets before closing in to exploit any armor breaches with their lasers. This does make the Catapult slightly more flexible than many traditional support 'Mechs, although its limited ammunition stores can hamper it in extended ranged battles.
+
+Deployment: While visible in every military of note, the Capellan Confederation and Draconis Combine would lay claim to the lion's share of the design. When production for the Catapult began in both states, the divide only increased, with many states losing all of their examples of the design by the conclusion of the Jihad. Even the base model would eventually disappear from the militaries of House Kurita and Liao. Now only commonly seen in periphery armies, the design still demands respect in this lower-technology environment.
+
+systemmanufacturer:CHASSIS:Hollis
+systemmode:CHASSIS:Mark II
+systemmanufacturer:ENGINE:Magna
+systemmode:ENGINE:260
+systemmanufacturer:ARMOR:Durallex
+systemmode:ARMOR:Heavy
+systemmanufacturer:COMMUNICATIONS:O/P
+systemmode:COMMUNICATIONS:Com-211
+systemmanufacturer:TARGETING:O/P
+systemmode:TARGETING:1078

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Daishi (Dire Wolf) Prime.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Daishi (Dire Wolf) Prime.mtf
@@ -1,0 +1,180 @@
+chassis:Daishi
+clanname:Dire Wolf
+model:Prime
+mul id:818
+
+Config:Biped Omnimech
+TechBase:Clan
+Era:3010
+Source:TRO: 3050
+Rules Level:2
+role:Juggernaut
+
+
+quirk:imp_target_long
+quirk:difficult_eject
+
+
+Mass:100
+Engine:300 XL (Clan) Engine(IS)
+Structure:IS Standard
+Myomer:Standard
+
+Heat Sinks:22 Double
+Base Chassis Heat Sinks:12
+Walk MP:3
+Jump MP:0
+
+Armor:Standard(Clan)
+LA Armor:34
+RA Armor:34
+LT Armor:32
+RT Armor:32
+CT Armor:47
+HD Armor:9
+LL Armor:41
+RL Armor:41
+RTL Armor:10
+RTR Armor:10
+RTC Armor:14
+
+Weapons:11
+ER Large Laser, Left Arm
+ER Large Laser, Left Arm
+Medium Pulse Laser, Left Arm
+Medium Pulse Laser, Left Arm
+Ultra AC/5, Left Arm
+ER Large Laser, Right Arm
+ER Large Laser, Right Arm
+Medium Pulse Laser, Right Arm
+Medium Pulse Laser, Right Arm
+Ultra AC/5, Right Arm
+LRM 10, Left Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+CLERLargeLaser (omnipod)
+CLERLargeLaser (omnipod)
+CLUltraAC5 (omnipod)
+CLUltraAC5 (omnipod)
+CLUltraAC5 (omnipod)
+CLMediumPulseLaser (omnipod)
+CLMediumPulseLaser (omnipod)
+Clan Ultra AC/5 Ammo (omnipod)
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+CLERLargeLaser (omnipod)
+CLERLargeLaser (omnipod)
+CLUltraAC5 (omnipod)
+CLUltraAC5 (omnipod)
+CLUltraAC5 (omnipod)
+CLMediumPulseLaser (omnipod)
+CLMediumPulseLaser (omnipod)
+Clan Ultra AC/5 Ammo (omnipod)
+-Empty-
+-Empty-
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLLRM10 (omnipod)
+Clan Ammo LRM-10 (omnipod)
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+
+Head:
+Life Support
+Sensors
+Cockpit
+-Empty-
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Dire Wolf is one of the OmniMechs that became feared throughout the Inner Sphere during the initial Clan Invasion and rightly so. 
+
+capabilities:The Dire Wolf weighs in at an impressive one hundred tons and has a relatively slow cruising speed of 54 km/h provided by a 300 XL engine. Its speed and armor protection matches that of an Atlas, but it has superior potential firepower with fifty and a half tons of free pod space for weapons and equipment. It is these traits which saw the 'Mech christened Daishi (pseudo-Japanese for "Great Death") by the criminal underbelly of the Draconis Combine, a name that would be proven grimly accurate time and time again.
+
+deployment:In its primary configuration, the Dire Wolf carries an extensive long range payload that is backed up by good close combat weapons. The primary long range weapons are four ER Large Lasers which give the Dire Wolf an impressive long range punch. These are backed up by two Ultra Autocannon/5s for even more direct fire capability and an LRM-10 launcher giving the Dire Wolf some indirect fire capabilities. For close combat, the Dire Wolf has a simple yet effective array of four Medium Pulse Lasers.
+
+history:The Dire Wolf was the brainchild of the Clan Wolf scientist caste, but was actually first produced by Clan Smoke Jaguar. Hearing rumors that Clan Wolf was developing the "Ultimate Assault OmniMech", the Jaguars won the plans and production rights in a trial that, rumor has it, was fought dishonorably. Production commenced on Huntress in 3010. In 3019, Clan Wolf began production of the OmniMech on Strana Mechty as well; Star Colonel Ulric won a trial of possession to expand manufacture into Clan Wolf. Beyond the limited manufacture of the Dire Wolf on Outreach, all Dire Wolves outside of Clans Smoke Jaguar and Wolf (or the Wolf's Dragoons) are either gifts, isorla, or were acquired through trade.
+
+manufacturer:Phan Industriplex, Wolf Clan Site #1, Svarstaad Industriplex Delta
+primaryfactory:Huntress, Strana Mechty, Svarstaad
+systemmanufacturer:CHASSIS:Titan HX
+systemmanufacturer:ENGINE:Starfire 300 XL
+systemmanufacturer:ARMOR:Compound 12B2 Standard
+systemmanufacturer:COMMUNICATIONS:TJ6 “Bell” Integrated Communication System
+systemmanufacturer:TARGETING:Mars System 9

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Locust LCT-1V.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Locust LCT-1V.mtf
@@ -1,0 +1,179 @@
+chassis:Locust
+model:LCT-1V
+mul id:1901
+
+Config:Biped
+TechBase:Inner Sphere
+Era:2499
+Source:TRO: 3039
+Rules Level:1
+role:Scout
+
+
+
+
+quirk:compact_mech
+quirk:low_profile
+quirk:cramped_cockpit
+quirk:no_arms
+quirk:weak_legs
+quirk:ubiquitous_clan
+quirk:ubiquitous_is
+
+
+Mass:20
+Engine:160 Fusion Engine
+Structure:Standard
+Myomer:Standard
+
+Heat Sinks:10 Single
+Walk MP:8
+Jump MP:0
+
+Armor:Standard(Inner Sphere)
+LA Armor:4
+RA Armor:4
+LT Armor:8
+RT Armor:8
+CT Armor:10
+HD Armor:8
+LL Armor:8
+RL Armor:8
+RTL Armor:2
+RTR Armor:2
+RTC Armor:2
+
+Weapons:3
+Medium Laser, Center Torso
+Machine Gun, Left Arm
+Machine Gun, Right Arm
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Machine Gun
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Machine Gun
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Medium Laser
+IS Ammo MG - Full
+
+Head:
+Life Support
+Sensors
+Cockpit
+-Empty-
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+
+Overview: The Locust is undoubtedly one of the most popular and prevalent light BattleMechs ever made. First produced in 2499, the almost dozen distinct factories manufacturing the design quickly spread it to every power in human space. Its combination of tough armor (for its size), exceptional speed, and most importantly, low cost have all contributed to the Locust's success. It remains the benchmark for many scouting designs, and its continual upgrades have ensured that it remains just as effective with every new conflict that appears.
+
+Capabilities: As the Locust was first developed as a recon platform, speed is paramount to the design's philosophy. While many variants change the weaponry to fill specific tasks or purposes, Locusts are nearly always pressed into service in ways where they can best take advantage of their speed. When in line regiments, they can act as a deadly flankers or harassers, and are often used in reactionary roles to quickly plug holes in a fluid battle line. The structural form of Locusts themselves are their greatest weakness; with no hands, they are disadvantaged in physical combat and occasionally have difficulty righting themselves after a fall.
+
+Deployment: One of the most common designs even produced, even the smallest mercenary or pirate outfits will often field one or more of the design. Production for the Locust has continued uninterrupted for centuries, and it plays an important role in the militaries of many smaller nations. The base LCT-1V was once estimated to account for more than 75% of all Locusts in existence at the end of the Succession Wars, though these numbers have dropped with the reappearance of more advanced technology. Still, it remains common in every military worth note.
+
+systemmanufacturer:CHASSIS:Bergan
+systemmode:CHASSIS:VII
+systemmanufacturer:ENGINE:LTV
+systemmode:ENGINE:160
+systemmanufacturer:ARMOR:StarSlab
+systemmode:ARMOR:/1
+systemmanufacturer:COMMUNICATIONS:Garrett
+systemmode:COMMUNICATIONS:T10-B
+systemmanufacturer:TARGETING:O/P
+systemmode:TARGETING:911

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Mad Cat (Timber Wolf) Prime.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Mad Cat (Timber Wolf) Prime.mtf
@@ -1,0 +1,178 @@
+chassis:Mad Cat
+clanname:Timber Wolf
+model:Prime
+mul id:1985
+
+Config:Biped Omnimech
+techbase:Clan
+era:2945
+source:TRO: 3050
+rules level:2
+role:Brawler
+
+
+quirk:imp_target_med
+quirk:weak_head_1
+
+
+mass:75
+engine:375 XL (Clan) Engine(IS)
+structure:Clan Endo Steel
+myomer:Standard
+
+heat sinks:17 Double
+base chassis heat sinks:15
+walk mp:5
+jump mp:0
+
+armor:Ferro-Fibrous(Clan)
+LA armor:24
+RA armor:24
+LT armor:25
+RT armor:25
+CT armor:36
+HD armor:9
+LL armor:32
+RL armor:32
+RTL armor:7
+RTR armor:7
+RTC armor:9
+
+Weapons:9
+ER Large Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Large Laser, Right Arm
+ER Medium Laser, Right Arm
+Medium Pulse Laser, Left Torso
+LRM 20, Left Torso
+Machine Gun, Right Torso
+LRM 20, Right Torso
+Machine Gun, Center Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLERLargeLaser (omnipod)
+CLERMediumLaser (omnipod)
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+CLDoubleHeatSink (omnipod)
+CLDoubleHeatSink (omnipod)
+CLERLargeLaser (omnipod)
+CLERMediumLaser (omnipod)
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLMediumPulseLaser (omnipod)
+Clan Ammo LRM-20 (omnipod)
+Clan Endo Steel
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+-Empty-
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLLRM20 (omnipod)
+CLMG (omnipod)
+Clan Ammo LRM-20 (omnipod)
+Clan Machine Gun Ammo - Full (omnipod)
+Clan Endo Steel
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+CLMG (omnipod)
+Clan Endo Steel
+
+Head:
+Life Support
+Sensors
+Cockpit
+Clan Ferro-Fibrous
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces (as opposed to periphery forces) on The Rock in 3049 by Phelan Kell. The Timber Wolf is vastly more powerful than either the Marauder or the Catapult. It uses its speed and firepower to engage an enemy at the range of its choosing. When first encountered by Inner Sphere forces the idea that a heavy 'Mech could move so swiftly while being as heavily armed and armored as the Timber Wolf was inconceivable. With its twelve tons of Ferro-Fibrous armor and arsenal that rivaled that of most assault 'Mechs of the era, it was completely alien to Inner Sphere military planners, commanders, and even the Precentor Martial of ComStar. Its technological secrets have since been reverse-engineered by the Inner Sphere.
+
+capabilities:The default configuration of the Timber Wolf features a well blended mix of energy and missile weaponry; primarily extended-range lasers and long range missile racks that give the Timber Wolf considerable firepower at medium and long range. A pair of LRM-20 racks supplemented by two Extended Range Large Lasers make up the bulk of the Timber Wolf's firepower. The Timber Wolf also has an array of lighter, shorter ranged weaponry for use once the 'Mech draws closer to its prey: two ER Medium Lasers and a Medium Pulse Laser. Finally, it has two Machine Guns for point defense against infantry. Even on the modern battlefield the primary configuration of the Timber Wolf is a force to be reckoned with.
+
+deployment:First introduced in 2945, the Timber Wolf was designed by Clan Wolf as a second generation OmniMech along with the Gargoyle and the Naga to replace the aging Woodsman. While the Gargoyle may have been a very capable, fast assault OmniMech, and the Naga may have been an excellent fire-support OmniMech, Clan Wolf (and indeed every other Clan) instantly realized the value of the Timber Wolf; thus, production rights to the Timber Wolf were jealously (and successfully) defended. Only through trade, gifts and battlefield salvage has the Timber Wolf entered the armies of other Clans. Until the invasion of the Inner Sphere, production of the Timber Wolf has been limited to a single facility on Strana Mechty. Despite it's prominence among the Wolves during the Clan Invasion, Refusal War and Word of Blake Jihad, the Timber Wolf became increasingly rare following the sundering of ties with the Homeworld Clans during the Wars of Reaving and Blakist scouring of Tamar. Being built by hand at W-7 plant on Weingarten as of 3080, with some parts even being individually machined due to missing data, attrition vastly outstripped supply as the Wolves looked toward other designs. When Alaric Ward forged the Wolf Empire, he left the W-7 facilities to Clan Hell's Horses and ordered the Kallon plant on Thermopolis be retooled for Timber Wolf production, restoring it's position within the Wolves touman.
+
+history:Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact. (The targeting computer on Phelan Kell's Wolfhound switched between MAD and CAT when trying to identify it; upon analyzing the data recording from Kell's 'Mech, Precentor Martial Anastasius Focht later officially designated it "Mad Cat".
+
+manufacturer:Wolf Clan Site #1, Wolf Clan Site #2, W-7 Facilities, Kallon Weapon Industries
+primaryfactory:Arc-Royal, Strana Mechty, Weingarten, Thermopolis 
+systemmanufacturer:CHASSIS:Type W3 Endo-steel
+systemmanufacturer:ENGINE:Starfire 375 XL
+systemmanufacturer:ARMOR:Composite A-2 Ferro-Fibrous
+systemmanufacturer:COMMUNICATIONS:Khan Series (Type 2c)
+systemmanufacturer:TARGETING:Series III OPT

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Phoenix Hawk C.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Phoenix Hawk C.mtf
@@ -1,0 +1,160 @@
+generator:MegaMek Suite 0.49.19-SNAPSHOT on 2024-03-16
+chassis:Phoenix Hawk
+model:C
+mul id:7752
+
+Config:Biped
+techbase:Clan
+era:2831
+source:Rec Guide:ilClan #11
+rules level:2
+role:Striker
+
+quirk:command_mech
+quirk:ubiquitous_clan
+quirk:ubiquitous_is
+quirk:imp_com
+
+mass:45
+engine:270 XL (Clan) Engine(IS)
+structure:Clan Endo Steel
+myomer:Standard
+
+heat sinks:10 Clan Double
+walk mp:6
+jump mp:6
+
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:18
+RT armor:18
+CT armor:23
+HD armor:8
+LL armor:20
+RL armor:20
+RTL armor:4
+RTR armor:4
+RTC armor:5
+
+Weapons:6
+Medium Pulse Laser, Left Arm
+Medium Pulse Laser, Right Arm
+Ultra AC/2, Left Torso
+Ultra AC/2, Right Torso
+Machine Gun, Center Torso
+Machine Gun, Head
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLMediumPulseLaser
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLMediumPulseLaser
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+Jump Jet
+Jump Jet
+Jump Jet
+CLUltraAC2
+CLUltraAC2
+Clan Ultra AC/2 Ammo
+Clan Machine Gun Ammo - Half
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+Jump Jet
+Jump Jet
+Jump Jet
+CLUltraAC2
+CLUltraAC2
+Clan Ultra AC/2 Ammo
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+CLMG
+Clan Endo Steel
+
+Head:
+Life Support
+Sensors
+Cockpit
+CLMG
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Rifleman C 3.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Rifleman C 3.mtf
@@ -1,0 +1,163 @@
+chassis:Rifleman
+model:C 3
+mul id:7576
+
+Config:Biped
+techbase:Clan
+era:3132
+source:Rec Guide:ilClan #8
+rules level:2
+role:Sniper
+
+
+
+quirk:anti_air
+quirk:imp_com
+quirk:searchlight
+quirk:ubiquitous_clan
+quirk:ubiquitous_is
+
+
+mass:60
+engine:240 Fusion (Clan) Engine(IS)
+structure:Clan Endo Steel
+myomer:Standard
+
+heat sinks:14 Clan Double
+walk mp:4
+jump mp:0
+
+armor:Ferro-Fibrous(Clan)
+LA armor:19
+RA armor:19
+LT armor:20
+RT armor:20
+CT armor:31
+HD armor:9
+LL armor:23
+RL armor:23
+RTL armor:5
+RTR armor:5
+RTC armor:8
+
+Weapons:6
+ER Large Laser, Left Arm
+Ultra AC/5, Left Arm
+ER Large Laser, Right Arm
+Ultra AC/5, Right Arm
+ER Medium Laser, Left Torso
+ER Medium Laser, Right Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+CLERLargeLaser
+CLUltraAC5
+CLUltraAC5
+CLUltraAC5
+Clan Ultra AC/5 Ammo
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+CLERLargeLaser
+CLUltraAC5
+CLUltraAC5
+CLUltraAC5
+Clan Ultra AC/5 Ammo
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLERMediumLaser
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+
+Right Torso:
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLERMediumLaser
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink
+CLDoubleHeatSink
+
+Head:
+Life Support
+Sensors
+Cockpit
+-Empty-
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Ryoken (Stormcrow) Prime.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Ryoken (Stormcrow) Prime.mtf
@@ -1,0 +1,173 @@
+chassis:Ryoken
+clanname:Stormcrow
+model:Prime
+mul id:2757
+
+Config:Biped Omnimech
+techbase:Clan
+era:2930
+source:TRO: 3050
+rules level:2
+role:Striker
+
+
+quirk:stable
+
+
+mass:55
+engine:330 XL (Clan) Engine(IS)
+structure:Clan Endo Steel
+myomer:Standard
+
+heat sinks:22 Clan Double
+base chassis heat sinks:10
+walk mp:6
+jump mp:0
+
+armor:Ferro-Fibrous(Clan)
+LA armor:18
+RA armor:18
+LT armor:17
+RT armor:17
+CT armor:25
+HD armor:9
+LL armor:25
+RL armor:25
+RTL armor:9
+RTR armor:9
+RTC armor:10
+
+Weapons:5
+ER Large Laser, Left Arm
+ER Medium Laser, Left Arm
+ER Large Laser, Right Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Head
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLERLargeLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLERLargeLaser (OMNIPOD)
+CLERMediumLaser (OMNIPOD)
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+Clan Endo Steel
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+CLDoubleHeatSink (OMNIPOD)
+Clan Endo Steel
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Clan Endo Steel
+Clan Ferro-Fibrous
+
+Head:
+Life Support
+Sensors
+Cockpit
+CLERMediumLaser (OMNIPOD)
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Clan Endo Steel
+Clan Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Stormcrow is a wide-spread, second generation OmniMech fielded by many Clans. However, within the Clan Smoke Jaguar touman, the Stormcrow was especially common during the Clan Invasion and was codenamed the Ryoken（a misspelling of ryōken - hunting dog) by the warriors of the DCMS who encountered it. Because of its versatility through its combination of mobility, armor, and firepower in its various configurations, the Stormcrow is a feared opponent on the battlefield.
+capabilities:The Stormcrow is built on a lightweight Endo Steel chassis and is powered by a 330 XL engine that propels it to a top speed of 97.2 km/h. The Stormcrow is protected by nine and a half tons of Ferro-Fibrous armor, giving the 'Mech the ability to survive encounters with other units that it isn't capable of outpacing.
+
+deployment:The primary configuration of the Stormcrow is capable of engaging an enemy at any range and uses its speed to strike at its target with a great deal of force and evade a counterattack. The 'Mech's primary weapons are a pair of ER large lasers allowing the 'Mech to strike at long range. For close combat, the Stormcrow carries three ER medium lasers. To handle the heavy heat load, the Stormcrow Prime has twelve double heat sinks on top of the ten mounted in the base chassis.
+
+history:The Stormcrow was designed by Clan Hell's Horses and debuted during the Battle of Tokasha. It is also implied that Stormcrow prototypes were produced on Tokasha at Tokasha MechWorks. However, prototypes of the Stormcrow had only just debuted when Clan Ghost Bear won Tokasha through the Battle of Tokasha. As a result of the upheaval, design copies and moulds for the Stormcrow were scattered throughout Clan space. The final production version of the Stormcrow debuted in 2930, when Clan Snow Raven scientists finished with a series of minor design changes and rechristened the OmniMech.
+
+manufacturer:Industrial Complex Alpha, Various
+primaryfactory:Dante,Various
+systemmanufacturer:CHASSIS:Model MHO-7E Endo-Steel
+systemmanufacturer:ENGINE:Fusion 330 Extralight
+systemmanufacturer:ARMOR:Compound H17/2 Ferro-Fibrous
+systemmanufacturer:COMMUNICATIONS:GBX Series Integrated
+systemmanufacturer:TARGETING:Tokasha B4-T&T
+

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Shadow Hawk SHD-2H.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Shadow Hawk SHD-2H.mtf
@@ -1,0 +1,178 @@
+chassis:Shadow Hawk
+model:SHD-2H
+mul id:2901
+
+Config:Biped
+TechBase:Inner Sphere
+Era:2550
+Source:TRO: 3039
+Rules Level:1
+role:Skirmisher
+
+
+
+quirk:battle_fists_la
+quirk:battle_fists_ra
+quirk:imp_life_support
+quirk:ubiquitous_clan
+quirk:ubiquitous_is
+quirk:rugged_1
+
+
+Mass:55
+Engine:275 Fusion Engine
+Structure:Standard
+Myomer:Standard
+
+Heat Sinks:12 Single
+Walk MP:5
+Jump MP:3
+
+Armor:Standard(Inner Sphere)
+LA Armor:16
+RA Armor:16
+LT Armor:18
+RT Armor:18
+CT Armor:23
+HD Armor:9
+LL Armor:16
+RL Armor:16
+RTL Armor:6
+RTR Armor:6
+RTC Armor:8
+
+Weapons:4
+SRM 2, Head
+LRM 5, Right Torso
+Autocannon/5, Left Torso
+Medium Laser, Right Arm
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+Medium Laser
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Jump Jet
+Autocannon/5
+Autocannon/5
+Autocannon/5
+Autocannon/5
+IS Ammo AC/5
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Heat Sink
+Jump Jet
+LRM 5
+IS Ammo LRM-5
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Jump Jet
+IS Ammo SRM-2
+
+Head:
+Life Support
+Sensors
+Cockpit
+SRM 2
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+
+Overview: The Shadow Hawk, from its inception, was designed to be a multi-purpose generalist. One of the fabled "trio" of 55-ton 'Mechs, its comrades are much more specialized designs. The Griffin is a long-ranged support platform, the Wolverine a heavy scout and skirmisher. The Shadow Hawk, however, can accomplish both roles—albeit, not as well as the two other designs. This has not hampered its popularity, and it has offered sterling service from the first days it entered battle.
+
+Capabilities: Most Shadow Hawks carry a varied array of weaponry. With both short and long-ranged weapons, missiles, lasers, and autocannons, the Shadow Hawk is never on a battlefield where it cannot contribute at least some firepower. Its speed is average for a design of its size, while the jump jets give it some maneuverability even on broken terrain. If the Shadow Hawk has one limitation, it is that it has difficulty bringing forward overwhelming firepower in any specific situation, causing some to disparage it as badly designed and flawed.
+
+Deployment: The Shadow Hawk is a widespread design. Every Successor State makes good use of the BattleMech, while the factories on Dunianshire ensure that a steady number enter periphery forces every year. As such a flexible design, it has a home in nearly every type of command, and few are the commanders who cannot find a use for their Shadow Hawk. Neither the massive number of upgrade kits nor the Jihad managed to put a dent in the number of SHD-2H's in service. Even today, the militaries from the greatest house to the lowliest mercenary group still use this venerable variant.
+
+systemmanufacturer:CHASSIS:Earthwerks
+systemmode:CHASSIS:SHD
+systemmanufacturer:ENGINE:CoreTek
+systemmode:ENGINE:275
+systemmanufacturer:ARMOR:Maximilian
+systemmode:ARMOR:43
+systemmanufacturer:COMMUNICATIONS:O/P
+systemmode:COMMUNICATIONS:300 COMSET
+systemmanufacturer:TARGETING:O/P
+systemmode:TARGETING:2000A

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Thor (Summoner) Prime.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Thor (Summoner) Prime.mtf
@@ -1,0 +1,174 @@
+chassis:Thor
+clanname:Summoner
+model:Prime
+mul id:3183
+
+Config:Biped Omnimech
+techbase:Clan
+era:2872
+source:TRO: Clan Invasion
+rules level:2
+role:Sniper
+
+
+quirk:imp_com
+quirk:ubiquitous_clan
+
+
+mass:70
+engine:350 XL (Clan) Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:14 Clan Double
+base chassis heat sinks:14
+walk mp:5
+jump mp:5
+
+armor:Ferro-Fibrous(Clan)
+LA armor:17
+RA armor:17
+LT armor:22
+RT armor:22
+CT armor:27
+HD armor:9
+LL armor:23
+RL armor:23
+RTL armor:7
+RTR armor:7
+RTC armor:8
+
+Weapons:3
+LB 10-X AC, Left Arm
+ER PPC, Right Arm
+LRM 15, Left Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+CLLBXAC10 (OMNIPOD)
+CLLBXAC10 (OMNIPOD)
+CLLBXAC10 (OMNIPOD)
+CLLBXAC10 (OMNIPOD)
+CLLBXAC10 (OMNIPOD)
+Clan LB 10-X AC Ammo (OMNIPOD)
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+CLERPPC (OMNIPOD)
+CLERPPC (OMNIPOD)
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Fusion Engine
+Fusion Engine
+CLLRM15 (OMNIPOD)
+CLLRM15 (OMNIPOD)
+Clan Ammo LRM-15 (OMNIPOD)
+Clan Ammo LRM-15 (OMNIPOD)
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Fusion Engine
+Fusion Engine
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Jump Jet
+-Empty-
+
+Head:
+Life Support
+Sensors
+Cockpit
+Clan Ferro-Fibrous
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Summoner is a highly mobile heavy OmniMech with a mix of speed, mobility, armor, and firepower. Making it a highly effective and reliable mech commonly used by Clan Jade Falcon in a wide variety of roles.
+
+capabilities:The Summoner is powered by a lightweight 350 XL engine that gives the 'Mech a top speed of 86.4 km/h. The mobility of the Summoner is enhanced with five jump jets that allow it to jump up to one hundred and fifty meters. The Summoner has fourteen double heat sinks which are capable of handling the heat produced in most of the 'Mechs configurations with ease. To protect it from damage, the Summoner carries nine and a half tons of Ferro-Fibrous armor.
+
+deployment:In its primary configuration the Summoner has a basic yet effective arsenal. The primary direct fire weapon is an ER PPC backed up by an LB 10-X Autocannon that can fire both standard and cluster ammunition. For fire support and bombardment, the Summoner has an LRM-15 launcher.
+
+history:Barely a second generation OmniMech, the Jade Falcons introduced the Summoner just after becoming the first Clan to win OmniMech technology from Clan Coyote in 2863. The Summoner was dubbed Thor, its Inner Sphere reporting name, by Victor Steiner-Davion himself after fighting one on Trellwan. The name was supposedly inspired by the weapons loadout (in Prime configuration): a PPC and an AC, lightning and thunder, which are associated with the Norse god Thor. Largely supplanted within the Jade Falcons by its successor the Grand Summoner during the Dark Age era, Clan Hell's Horses maintained production of the original on Svarstaad, ensuring by 3150 the Summoner was the oldest continuously produced OmniMech.
+
+manufacturer:Eagle Craft Group, St. Louis MechWorks, Svarstaad Industriplex Gamma
+primaryfactory:Ironhold, Niles, Svarstaad
+systemmanufacturer:CHASSIS:JFS-703
+systemmanufacturer:ENGINE:Redline 350 XL
+systemmanufacturer:ARMOR:J63-3E Ferro Fibrous
+systemmanufacturer:JUMPJET:JF Standard
+systemmanufacturer:COMMUNICATIONS:Model J-D 067
+systemmanufacturer:TARGETING:Hawkeye 58
+

--- a/MegaMekParser.Mtf.Tests/TestData/Mechs/Warhammer WHM-6R.mtf
+++ b/MegaMekParser.Mtf.Tests/TestData/Mechs/Warhammer WHM-6R.mtf
@@ -1,0 +1,181 @@
+chassis:Warhammer
+model:WHM-6R
+mul id:3488
+Config:Biped
+techbase:Inner Sphere
+era:2515
+source:TRO: 3039
+rules level:1
+role:Brawler
+
+
+
+
+quirk:rugged_2
+quirk:searchlight
+quirk:stable
+quirk:ubiquitous_clan
+quirk:ubiquitous_is
+
+
+mass:70
+engine:280 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:18 Single
+walk mp:4
+jump mp:0
+
+armor:Standard(Inner Sphere)
+LA armor:20
+RA armor:20
+LT armor:17
+RT armor:17
+CT armor:22
+HD armor:9
+LL armor:15
+RL armor:15
+RTL armor:8
+RTR armor:8
+RTC armor:9
+
+Weapons:9
+PPC, Left Arm
+PPC, Right Arm
+Medium Laser, Left Torso
+Small Laser, Left Torso
+Machine Gun, Left Torso
+SRM 6, Right Torso
+Medium Laser, Right Torso
+Small Laser, Right Torso
+Machine Gun, Right Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Heat Sink
+PPC
+PPC
+PPC
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Heat Sink
+PPC
+PPC
+PPC
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Medium Laser
+Small Laser
+Machine Gun
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+SRM 6
+SRM 6
+Medium Laser
+Small Laser
+Machine Gun
+IS Ammo SRM-6
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+IS Ammo MG - Full
+-Empty-
+
+Head:
+Life Support
+Sensors
+Cockpit
+Heat Sink
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+Heat Sink
+Heat Sink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:The Warhammer proved to be a very capable 'Mech, and for centuries practically defined the entire class of heavy 'Mechs. Boasting incredible firepower and respectable armoring, the Warhammer served prominently in the Star League Defense Force and was one of the premier 'Mechs in the Gunslinger Program. Indeed, many of the greatest MechWarriors in history were Warhammer pilots.
+
+capabilities:The Warhammer was well-protected with strong armor for its age and weight, and the large number of heat sinks allowed it to "fire and maneuver" without fear. The most common engine arrangement propels the 'Mech to a cruising speed of 43.2 km/h and a top speed of 64.8 km/h, which is quick enough to keep up with most battles. The 'Mech's electronics, albeit antiquated by the 31st Century, were basic and functional, allowing it to assume command tasks when necessary. The targeting mechanism, in particular, made use of an unique Searchlight positioned above the 'Mech's left shoulder. The device could act as a conventional searchlight or immediately connect to the O/P 1500 ARB tracking system, transforming the 'Mech into a capable night fighter.
+
+deployment:The Warhammer 6R's primary armaments were a pair of arm-mounted Donal PPCs that utilised highly charged accelerated particles to deal severe damage to opponent 'Mechs at long ranges. Both PPCs together offered the combined firepower of an Autocannon/20 over a far larger range bracket. The Warhammer carried two Martell medium lasers and two Magna tiny lasers for close combat, one on each side of the torso. A Holly SRM-6 was carried over the right shoulder, with one ton of reloads in the corresponding side torso, to exploit any weak places in an enemy's armor. Ultimately, two Sperry Browning Machine Guns were distributed between the side torsos, with one ton of ammunition carried in the middle torso as a strong deterrent to infantry attacks.
+
+history:StarCorps Industries introduced the Warhammer BattleMech in 2515 as "a mobile 'Mech with adequate firepower to destroy or severely damage any 'Mech of the same weight class or lower." The Warhammer continued to serve in the forces of the Great Houses throughout the Succession Wars after the Star League's demise. Despite very modest production rates, the large number of Warhammer factories dispersed over both the Inner Sphere and Periphery contributed to its endurance; Ronin Inc. was never able to construct more than five Warhammers per year from their Wallis factory. The recovery of the Helm Memory Core would prompt Inner Sphere manufacturers to create a slew of new Lostech-powered Warhammer versions, while the Periphery continued to produce original models for mercenaries and black marketeers. After the Clan Invasion, StarCorps chose to rehabilitate the ancient 'Mech with the greatest technological advancements, giving it new life. Initially, the business planned to construct only one new variety from its Crofton plant, but when word of the idea spread, other departments within StarCorps became involved and gathered on Crofton for a week-long conference to iron out the details. The conference turned out to be more jubilant than expected, and at the end of the bacchanalian "negotiations," it was determined that four new variations would be built: one for each of the Federated Suns, Capellan, Free Worlds League, and Lyran forces, employing technology unique to each realm. During the FedCom Civil War, some of these new 'Mechs were put through their paces.
+
+manufacturer:Diplass BattleMechs,StarCorps (FWL) Industries,StarCorps Industries,Amalgamated Sword and Steel,Vandenberg Mechanized Industries,Hope Industrial Works,Olivetti Weaponry (Formerly Earthwerks Inc.),Taurus Territorial Industries,Nimakachi Fusion Products Ltd.,StarCorps Industries,Ronin Inc. (Selasys)
+primaryfactory:Apollo,Emris IV,Fletcher (TH),Oldsmith,Pinard,Randis IV,Sudeten,Taurus,Tematagi,Terra,Wallis,
+systemmanufacturer:CHASSIS:StarCorps 100
+systemmanufacturer:ENGINE:VOX 280
+systemmanufacturer:ARMOR:Leviathon Plus
+systemmanufacturer:COMMUNICATIONS:O/P 3000 COMSET
+systemmanufacturer:TARGETING:O/P 1500 ARB
+


### PR DESCRIPTION
## Summary
- expand sample mech parser tests with additional OmniMechs and clan variants
- include new official MTF files such as "Thor (Summoner) Prime" and "Rifleman C 3"

## Testing
- `dotnet test MegaMekAbstractions.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb35af008328be87a298d53506a1