### PR TITLE
Sync enums with latest MegaMek

### DIFF
--- a/MegaMekAbstractions/Common/Quirk.cs
+++ b/MegaMekAbstractions/Common/Quirk.cs
@@ -70,7 +70,7 @@ public enum Quirk
     EmInterference,
     ExposedActuators,
     FlawedCooling,
-    FragileEngine,
+    FragileFuel,
     GasHog,
     HardPilot,
     IllegalDesign,
@@ -83,6 +83,12 @@ public enum Quirk
     OverSized,
     PoorLifeSupport,
     PoorPerformance,
+    PoorSealing,
+    PoorTargetingLong,
+    PoorTargetingMedium,
+    PoorTargetingShort,
+    PoorWork,
+    Prototype,
     Ramshackle,
     SensorGhosts,
     SusceptibleCws, // Not sure what this means yet
@@ -102,5 +108,7 @@ public enum Quirk
     NoCooling,
     NonFunctional,
     PoorCooling,
-    StaticFeed
+    StaticFeed,
+    MisrepairedWeapon,
+    MisreplacedWeapon
 }

--- a/MegaMekAbstractions/Mechs/EngineType.cs
+++ b/MegaMekAbstractions/Mechs/EngineType.cs
@@ -5,14 +5,19 @@ namespace MegaMekAbstractions.Mechs;
 /// </summary>
 public enum EngineType
 {
-    Standard,
-    XL,
-    Light,
-    Compact,
-    ICE,
-    XXL,
-    Primitive,
-    Fuel_Cell,
-    Fission,
-    None
+    ICE = 0,
+    Standard = 1,
+    XL = 2,
+    XXL = 3,
+    Fuel_Cell = 4,
+    Light = 5,
+    Compact = 6,
+    Fission = 7,
+    None = 8,
+    MagLev = 9,
+    Steam = 10,
+    Battery = 11,
+    Solar = 12,
+    External = 13,
+    Primitive = 14
 }


### PR DESCRIPTION
## Summary
- update `Quirk` with missing negative quirk names and rename FragileFuel
- expand `EngineType` to include newer engine constants with explicit values

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb34807483289cf4a5fd4ad193b8